### PR TITLE
Mirror WORKSPACE_* RoleBindings to DEPLOYMENT_* RoleBindings

### DIFF
--- a/src/lib/rbac/deployment-fragment.js
+++ b/src/lib/rbac/deployment-fragment.js
@@ -1,0 +1,4 @@
+export default `{
+  id
+  workspace { id }
+}`;

--- a/src/resolvers/mutation/create-deployment/index.js
+++ b/src/resolvers/mutation/create-deployment/index.js
@@ -83,16 +83,18 @@ export default async function createDeployment(parent, args, ctx, info) {
   );
 
   // Create the role binding for the user.
-  await ctx.db.mutation.createRoleBinding(
-    {
-      data: {
-        role: DEPLOYMENT_ADMIN,
-        user: { connect: { id: ctx.user.id } },
-        deployment: { connect: { id: deployment.id } }
-      }
-    },
-    `{ id }`
-  );
+  // XXX: This was commented out temporarily while we are
+  // synthetically generating DEPLOYMENT_* RoleBindings.
+  // await ctx.db.mutation.createRoleBinding(
+  //   {
+  //     data: {
+  //       role: DEPLOYMENT_ADMIN,
+  //       user: { connect: { id: ctx.user.id } },
+  //       deployment: { connect: { id: deployment.id } }
+  //     }
+  //   },
+  //   `{ id }`
+  // );
 
   // Create the database for this deployment.
   const {


### PR DESCRIPTION
This allows all WORKSPACE_* roles to be cascaded down to synthetically generated DEPLOYMENT_* roleBindings.

This is to help us grandually introduce the RBAC system.

I also stopped adding the initial DEPLOYMENT_ADMIN RoleBinding. Someone could be downgraded at a later date to a WORKSPACE_VIEWER, and thus a DEPLOYMENT_VIEWER, but would still retain the original DEPLOYMENT_ADMIN roleBinding that is essentially hidden from the user at this point. This prevents that situation and we rely purely on the synthetic roleBindings for DEPLOYMENTs for now.