### PR TITLE
Improve handling of duplicate email error

### DIFF
--- a/src/lib/errors/errors.js
+++ b/src/lib/errors/errors.js
@@ -112,6 +112,9 @@ export class DuplicateRoleBindingError extends UserInputError {
   message = this.message || "A duplicate role binding already exists";
 }
 
-export class DuplicateEmailError extends Error {
-  message = this.message || "Email already in use";
+export class DuplicateEmailError extends ApolloError {
+  name = "DuplicateEmailError";
+  constructor() {
+    super("Email address in use", "DUPLICATE_EMAIL");
+  }
 }

--- a/src/lib/errors/prisma.js
+++ b/src/lib/errors/prisma.js
@@ -1,5 +1,5 @@
 import { DuplicateEmailError } from "./errors";
-import { includes, some } from "lodash";
+import { some } from "lodash";
 
 /*
  * Take an error from prisma, and throw an error
@@ -8,7 +8,9 @@ import { includes, some } from "lodash";
  * @param {Object} error The prisma error.
  */
 export function throwPrismaError(e) {
-  if (duplicateEmailError(e)) throw new DuplicateEmailError();
+  if (duplicateEmailError(e)) {
+    throw new DuplicateEmailError();
+  }
 }
 
 /*
@@ -17,15 +19,19 @@ export function throwPrismaError(e) {
  * @return {Boolean} If a uplicate user error is found.
  */
 export function duplicateEmailError(e) {
-  return hasError(e, "A unique constraint would be violated on User");
+  return hasError(e, 3010, /\b(?:User|Email)\b/);
 }
 
 /* Generic function to look for a message in an array
  * of errors from GraphQL.
+ *
+ * Error codes come from https://github.com/prisma/prisma/blob/5d6e09c2fb1a68dc9e05765629cf31ae3a22bcd4/server/connectors/api-connector/src/main/scala/com/prisma/api/schema/Errors.scala
+ *
  * @param {Object} error An error object from prisma (or any GraphQL server).
- * @param {String} msg A message to look for in the array.
+ * @param {Number} code The prisma server error code to look for
+ * @param {RegExp} msg A message to look for in the array.
  * @return {Boolean} If the message was found.
  */
-export function hasError(e, msg) {
-  return some(e.result.errors, e => includes(e.message, msg));
+export function hasError(e, code, re) {
+  return some(e.result.errors, e => e.code == code && e.message.match(re));
 }


### PR DESCRIPTION
The mutation that Orbit sent would trigger this, but a custom crafted mutation was possible to hit a different unique constraint instead.

This also gives us a dedicated code that we can make decisions on in the UI instead of relying on the text of the error message:

```json
{
  "errors": [
    {
      "message": "Email address in use",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "createUser"
      ],
      "extensions": {
        "code": "DUPLICATE_EMAIL",
      }
    }
  ]
}
```