### PR TITLE
Use cluster networking to access registry from houston

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -109,6 +109,7 @@ repository: "https://helm.astronomer.io/"
 helm:
   baseDomain: ~
   registryAuthSecret: ~
+  registryPort: 5000
   releaseName: ~
   releaseNamespace: ~
   releaseVersion: ~

--- a/src/resolvers/types/deployment/index.js
+++ b/src/resolvers/types/deployment/index.js
@@ -1,3 +1,4 @@
+import log from "logger";
 import {
   generateNamespace,
   generateEnvironmentSecretName
@@ -98,9 +99,12 @@ export async function deployInfo(parent) {
     }
   ]);
 
+  const namespace = config.get("helm.releaseNamespace");
+  const releaseNamePlatform = config.get("helm.releaseName");
+  const registryPort = config.get("helm.registryPort");
   // Build the registry request URL.
-  const baseDomain = config.get("helm.baseDomain");
-  const uri = `https://registry.${baseDomain}/v2/${repo}/tags/list`;
+  const uri = `http://${releaseNamePlatform}-registry.${namespace}:${registryPort}/v2/${repo}/tags/list`;
+  log.debug(`Using cluster URI to access registry: ${uri}`)
 
   try {
     // Request a list of tags.


### PR DESCRIPTION
We ought to avoid calling back through the ingress when inside the platform. It causes issues in the case of our ingress using L4 load balancing (TCP) rather than L7 (HTTP) or in the case where internal services do not have access to the load balancer as resolved by public DNS.

This probably occurs in a few other places. I'm trying to keep PRs in houston small since I'm new to it. Please review considering that I know very little JS, so I might miss basic conventions.