### PR TITLE
Debug typo

### DIFF
--- a/src/resolvers/types/deployment/index.js
+++ b/src/resolvers/types/deployment/index.js
@@ -100,7 +100,10 @@ export async function deployInfo(parent) {
   ]);
 
   // Grab some configuration.
-  const { releaseNamespace: namespace, releaseName: platformReleaseName } = config.get("helm");
+  const {
+    releaseNamespace: namespace,
+    releaseName: platformReleaseName
+  } = config.get("helm");
   const registryPort = config.get("registry.port");
 
   // Build the registry request URL.

--- a/src/resolvers/types/deployment/index.js
+++ b/src/resolvers/types/deployment/index.js
@@ -100,7 +100,7 @@ export async function deployInfo(parent) {
   ]);
 
   // Grab some configuration.
-  const { namespace, releaseName: platformReleaseName } = config.get("helm");
+  const { releaseNamespace: namespace, releaseName: platformReleaseName } = config.get("helm");
   const registryPort = config.get("registry.port");
 
   // Build the registry request URL.


### PR DESCRIPTION
```
# Helm configuration.
# These values are set at runtime and used for airflow deployments.
helm:
  baseDomain: ~
  registryAuthSecret: ~
  releaseName: ~
  releaseNamespace: ~
  releaseVersion: ~
  singleNamespace: false
```
https://github.com/astronomer/houston-api/blob/master/config/default.yaml