### PR TITLE
Add support for admins to edit service accounts

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -209,6 +209,11 @@ roles:
       - system.deployments.metrics
       - system.users.list
       - system.workspace.addCustomerId
+      # XXX: Refactor serviceAccount permissions
+      - system.serviceAccounts.list
+      - system.serviceAccounts.create
+      - system.serviceAccounts.update
+      - system.serviceAccounts.delete
 
   - id: SYSTEM_EDITOR
     name: System Editor


### PR DESCRIPTION
This PR adds support for admins to be able to query/update/delete service accounts. If an admin currently navigates to a deployment from the admin panel (that they wouldn't normally have access to), they get errors on the service account pages. This addresses this issue.

We should really refactor these, as noted in https://github.com/astronomer/issues/issues/217, but this gets us running for v0.10.1.