### PR TITLE
Move production Dockerfile and build to this repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,123 @@
+version: 2.1
+jobs:
+  build:
+    executor: docker-executor
+    steps:
+      - docker-build:
+          image_name: ap-houston-api
+  scan:
+    executor: clair-scanner/default
+    steps:
+      - clair-scan:
+          image_name: ap-houston-api
+  publish-dev:
+    executor: docker-executor
+    steps:
+      - push:
+          comma_separated_tags: "dev,edge,$CIRCLE_SHA1"
+          image_name: ap-houston-api
+  publish-prod:
+    executor: docker-executor
+    steps:
+      - push:
+          comma_separated_tags: "master,latest"
+          image_name: ap-houston-api
+workflows:
+  version: 2.1
+  build-images:
+    jobs:
+      - build
+      - scan:
+          requires:
+            - build
+      - publish-dev:
+          requires:
+            - scan
+      - publish-prod:
+          requires:
+            - scan
+          filters:
+            branches:
+              only: master
+orbs:
+  clair-scanner: ovotech/clair-scanner@1.6.0
+executors:
+  docker-executor:
+    environment:
+      GIT_ORG: astronomerinc
+    docker:
+      - image: circleci/buildpack-deps:stretch
+commands:
+  docker-build:
+    description: "Build a Docker image"
+    parameters:
+      dockerfile:
+        type: string
+        default: Dockerfile
+      path:
+        type: string
+        default: "."
+      image_name:
+        type: string
+        default: $CIRCLE_PROJECT_REPONAME
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build the Docker image
+          command: |
+            set -xe
+            image_name="<< parameters.image_name >>"
+            docker build -t $image_name --file << parameters.path>>/<< parameters.dockerfile >> --build-arg BUILD_NUMBER=${CIRCLE_BUILD_NUM} << parameters.path >>
+            docker save -o << parameters.image_name >>.tar $image_name
+      - persist_to_workspace:
+          root: .
+          paths:
+            - './*.tar'
+  clair-scan:
+    description: "Vulnerability scan a Docker image"
+    parameters:
+      image_name:
+        type: string
+        default: $CIRCLE_PROJECT_REPONAME
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Move tarball to directory for scan
+          command: mkdir /tmp/tarballs && mv /tmp/workspace/<< parameters.image_name >>.tar /tmp/tarballs/
+      - clair-scanner/scan:
+          docker_tar_dir: /tmp/tarballs
+  push:
+    description: "Push a Docker image to DockerHub"
+    parameters:
+      comma_separated_tags:
+        type: string
+        default: latest
+      organization:
+        type: string
+        default: $GIT_ORG
+      image_name:
+        type: string
+        default: $CIRCLE_PROJECT_REPONAME
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/<< parameters.image_name >>.tar
+      - run:
+          name: Login to DockerHub
+          command: echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
+      - run:
+          name: Push Docker image(s)
+          command: |
+            set -e
+            for tag in $(echo "<< parameters.comma_separated_tags >>" | sed "s/,/ /g");
+            do
+              set -x
+              docker tag << parameters.image_name >> << parameters.organization >>/<< parameters.image_name >>:${tag}
+              docker push << parameters.organization >>/<< parameters.image_name >>:${tag}
+              set +x
+            done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,18 +10,24 @@ jobs:
     steps:
       - clair-scan:
           image_name: ap-houston-api
-  publish-dev:
-    executor: docker-executor
-    steps:
-      - push:
-          comma_separated_tags: "dev,edge,$CIRCLE_SHA1"
-          image_name: ap-houston-api
-  publish-prod:
+  publish-master:
     executor: docker-executor
     steps:
       - push:
           comma_separated_tags: "master,latest"
           image_name: ap-houston-api
+  release:
+    executor: docker-executor
+    steps:
+      - checkout
+      - get-next-tag:
+          image_name: ap-houston-api
+      - push:
+          comma_separated_tags: "$NEXT_TAG,$CIRCLE_BRANCH"
+          image_name: ap-houston-api
+      # Publish a GitHub release on this repository,
+      # automatically generating a change log.
+      - publish-github-release
 workflows:
   version: 2.1
   build-images:
@@ -30,23 +36,34 @@ workflows:
       - scan:
           requires:
             - build
-      - publish-dev:
-          requires:
-            - scan
-      - publish-prod:
+      - publish-master:
           requires:
             - scan
           filters:
             branches:
               only: master
+      - approve-release:
+          type: approval
+          requires:
+            - scan
+          filters:
+            branches:
+              only: '/release-.*/'
+      - release:
+          requires:
+            - approve-release
+          filters:
+            branches:
+              only: '/release-.*/'
 orbs:
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
   docker-executor:
     environment:
-      GIT_ORG: astronomerinc
+      GIT_ORG: astronomer
+      DOCKER_REPO: astronomerinc
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: circleci/python:3
 commands:
   docker-build:
     description: "Build a Docker image"
@@ -62,7 +79,8 @@ commands:
         default: $CIRCLE_PROJECT_REPONAME
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Build the Docker image
           command: |
@@ -94,9 +112,9 @@ commands:
       comma_separated_tags:
         type: string
         default: latest
-      organization:
+      docker_repository:
         type: string
-        default: $GIT_ORG
+        default: $DOCKER_REPO
       image_name:
         type: string
         default: $CIRCLE_PROJECT_REPONAME
@@ -117,7 +135,143 @@ commands:
             for tag in $(echo "<< parameters.comma_separated_tags >>" | sed "s/,/ /g");
             do
               set -x
-              docker tag << parameters.image_name >> << parameters.organization >>/<< parameters.image_name >>:${tag}
-              docker push << parameters.organization >>/<< parameters.image_name >>:${tag}
+              # If the tag looks starts with "v" then a digit, remove the "v"
+              pattern="^(v[0-9].*)"
+              if [[ $tag =~ $pattern ]]; then
+                tag="${tag:1}"
+              fi
+              docker tag << parameters.image_name >> << parameters.docker_repository >>/<< parameters.image_name >>:${tag}
+              docker push << parameters.docker_repository >>/<< parameters.image_name >>:${tag}
               set +x
             done
+  publish-github-release:
+    description: "Create a release on GitHub"
+    parameters:
+      tag:
+        type: string
+        default:  "$NEXT_TAG"
+      ghr_version:
+        type: string
+        default:  "0.13.0"
+    steps:
+      - run:
+          name: Create a release on GitHub
+          command: |
+            set -xe
+            # Install ghr, a CLI tool for doing GitHub releases
+            WORK_DIR=$(pwd)
+            cd /tmp
+            wget https://github.com/tcnksm/ghr/releases/download/v<< parameters.ghr_version >>/ghr_v<< parameters.ghr_version >>_linux_amd64.tar.gz
+            tar -xvf ./ghr_v<< parameters.ghr_version >>_linux_amd64.tar.gz
+            mkdir -p /tmp/bin
+            mv ghr_v<< parameters.ghr_version >>_linux_amd64/ghr /tmp/bin/
+            export PATH=/tmp/bin:$PATH
+            cd $WORK_DIR
+
+            # Generate release notes in Markdown format
+            COMMITS=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"* %ai %h: %s" | awk '{$4=""; print $0}')
+            AUTHORS=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"%aE" | awk '!a[$0]++')
+            cat \<<EOT > /tmp/release_notes.md
+
+            ## Changes:
+
+            $COMMITS
+
+            ## Authors:
+
+            $AUTHORS
+            EOT
+
+            echo "==================="
+            cat /tmp/release_notes.md
+            echo "==================="
+
+            ghr \
+              -t $GITHUB_TOKEN \
+              -c $CIRCLE_SHA1 \
+              -n v<< parameters.tag>> \
+              -b "$(cat /tmp/release_notes.md)" \
+              v<< parameters.tag>>
+  get-next-tag:
+    description: "Set an environment variable to this release branch with an incremented patch version"
+    parameters:
+      docker_repository:
+        type: string
+        default: $DOCKER_REPO
+      image_name:
+        type: string
+        default: $CIRCLE_PROJECT_REPONAME
+    steps:
+      - run:
+          name: Determine the next patch version
+          command: |
+            set -e
+            pip install --user packaging requests
+            cat > /tmp/next_patch_version.py \<<- EOM
+            import os
+            import re
+            import sys
+            import json
+            import requests
+            from packaging.version import parse as semver
+
+            branch = os.environ['CIRCLE_BRANCH']
+            release_regex = re.compile("release-(\d*\.\d*)")
+
+            major_minor_version = release_regex.findall(branch)
+            most_recent_tag = None
+
+            if not len(major_minor_version):
+                print(f"Error: we are not on a release branch, should not call get-next-tag. This is used to find the next patch version", file=sys.stderr)
+                exit(1)
+
+            major_minor_version = major_minor_version[0]
+            print(f"We are on a release branch: {branch}, detected major.minor version {major_minor_version}", file=sys.stderr)
+            print(f"We will find the most recent patch version of {major_minor_version} and return it incremented by one", file=sys.stderr)
+
+            # Find all tags, paginating
+            repository = "<< parameters.docker_repository >>"
+            image = "<< parameters.image_name >>"
+            i = 1
+            tags = []
+            while True:
+              url = f"https://registry.hub.docker.com/v2/repositories/{repository}/{image}/tags/?page_size=100&page={i}"
+              response = requests.get(url)
+              content = json.loads(response.content)
+              names = [tag['name'] for tag in content['results']]
+              tags += names
+              if not len(names):
+                  break
+              i += 1
+
+            for tag in tags:
+                version = semver(tag).release
+                # skip any tags not parsed as a semantic version
+                if not version:
+                  continue
+                this_major_minor = f"{version[0]}.{version[1]}"
+                if this_major_minor == major_minor_version:
+                    most_recent_tag = tag
+                    print(f"The most recent tag matching this release is {most_recent_tag}", file=sys.stderr)
+                    break
+
+            if most_recent_tag:
+                base_version = semver(most_recent_tag).base_version
+                print(f"Parsed base version as {base_version}", file=sys.stderr)
+                base_version = semver(base_version)
+                major, minor, patch = base_version.release
+                patch += 1
+                new_version = ".".join(str(i) for i in [major, minor, patch])
+            else:
+                print("Did not detect a most recent version. Setting patch number to zero.", file=sys.stderr)
+                new_version = major_minor_version + ".0"
+
+            new_tag_regex = re.compile('\d*\.\d*\.\d*')
+            assert len(new_tag_regex.findall(new_version)), \
+                f"Error, did not produce a new tag in the form {new_tag_regex.pattern}"
+            print(f"Calculated new version as {new_version}", file=sys.stderr)
+            sys.stdout.write(new_version)
+            EOM
+            NEXT_TAG=$(python /tmp/next_patch_version.py)
+            # Make this environment variable available to following steps
+            echo "export NEXT_TAG=${NEXT_TAG}" >> $BASH_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,45 @@
 #
-# Houston API
-# Source of truth for the Astronomer Platform
+# Copyright 2019 Astronomer Inc.
+#
+# Licensed under the Apache License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-FROM alpine:3.10
-MAINTAINER Astronomer <humans@astronomer.io>
+FROM astronomerinc/ap-base:0.10.3
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 LABEL io.astronomer.docker.module="astronomer"
-LABEL io.astronomer.docker.component="houston"
-LABEL io.astronomer.docker.environment="development"
+LABEL io.astronomer.docker.component="houston-api"
 
-# Set and switch to installation directory.
 WORKDIR /houston
 
-# Add packages.json first so we can prevent rebuilds for code changes.
-COPY package.json package.json
+COPY . .
 
-# Install packages / dependencies.
-RUN apk update \
-	&& apk add --no-cache --virtual .build-deps \
+RUN apk add --no-cache --virtual .build-deps \
 		build-base \
-		python \
 		git \
+		python \
 	&& apk add --no-cache \
-		bash \
-		netcat-openbsd \
 		nodejs \
 		nodejs-npm \
 		openssl \
 	&& npm install \
+	&& npm run build \
 	&& apk del .build-deps
 
-# Copy in source code.
-COPY . .
-
-# Expose port and run default start command.
 EXPOSE 8871
 
 # Wrap with entrypoint
 ENTRYPOINT ["/houston/bin/entrypoint"]
-CMD ["npm", "run", "start"]
+
+CMD ["npm", "run", "serve"]


### PR DESCRIPTION
- Same idea as the Orbit PR, and the config for circle is almost identical. https://github.com/astronomer/orbit-ui/pull/184
- The Dockerfile is almost the same as it was on astronomer/astronomer master, but I put it to version 0.10.3 ap-base and removed the git cloning part of it

Same pre-merge checklist as Orbit:
- [ ] Circle CI: Turn on for this repo
- [ ] Circle CI: Opt-in to third party orbs
- [ ] Circle CI: Add DOCKER_USERNAME, DOCKER_PASSWORD, and GITHUB_TOKEN to circle CI environment variables

Sample run (on my fork, my dockerhub):
![image](https://user-images.githubusercontent.com/7516283/68974705-6140b500-07bf-11ea-886f-7f88143f3a68.png)

epic: https://github.com/astronomer/issues/issues/465
