### PR TITLE
Extend capabilities + add authUserCapabilites

### DIFF
--- a/src/resolvers/types/auth-user/index.js
+++ b/src/resolvers/types/auth-user/index.js
@@ -1,4 +1,5 @@
 import fragment from "./fragment";
+import { hasPermission } from "rbac";
 import { createAuthJWT, setJWTCookie } from "jwt";
 import { addFragmentToInfo } from "graphql-binding";
 import { USER_STATUS_ACTIVE } from "constants";
@@ -43,5 +44,28 @@ export function isAdmin() {
   return false;
 }
 
+/*
+ * Return boolean flags indicating what the current user has access to
+ * on a particular deployment.
+ * @param {Object} parent The result of the parent resolver.
+ * @param {Object} args The graphql arguments.
+ * @param {Object} ctx The graphql context.
+ * @return {AuthUserCapabilities} Map of boolean capabilities.
+ */
+export function authUserCapabilities(parent, args, ctx) {
+  const permissions = [
+    {
+      key: "canSysAdmin",
+      value: "system.airflow.admin"
+    }
+  ];
+  const capabilities = [];
+  permissions.map(p => {
+    capabilities[p.key] = hasPermission(ctx.user, p.value);
+  });
+
+  return capabilities;
+}
+
 // Export AuthUser.
-export default { user, token, permissions, isAdmin };
+export default { user, token, permissions, isAdmin, authUserCapabilities };

--- a/src/resolvers/types/deployment/index.js
+++ b/src/resolvers/types/deployment/index.js
@@ -119,15 +119,44 @@ export async function deployInfo(parent, args, ctx) {
  * @return {DeploymentCapabilities} Map of boolean capabilities.
  */
 export function deploymentCapabilities(parent, args, ctx) {
-  // Check to see if user has permission to deploy
-  const canDeploy = hasPermission(
-    ctx.user,
-    "deployment.images.push",
-    ENTITY_DEPLOYMENT.toLowerCase(),
-    parent.id
-  );
+  const permissions = [
+    {
+      key: "canDeploy",
+      value: "deployment.images.push"
+    },
+    {
+      key: "canUpdateDeployment",
+      value: "deployment.config.update"
+    },
+    {
+      key: "canDeleteDeployment",
+      value: "deployment.config.delete"
+    },
+    {
+      key: "canCreateServiceAccount",
+      value: "deployment.serviceAccounts.create"
+    },
+    {
+      key: "canUpdateServiceAccount",
+      value: "deployment.serviceAccounts.update"
+    },
+    {
+      key: "canDeleteServiceAccount",
+      value: "deployment.serviceAccounts.delete"
+    }
+  ];
 
-  return { canDeploy };
+  const capabilities = [];
+  permissions.map(p => {
+    capabilities[p.key] = hasPermission(
+      ctx.user,
+      p.value,
+      ENTITY_DEPLOYMENT.toLowerCase(),
+      parent.id
+    );
+  });
+
+  return capabilities;
 }
 
 export default {

--- a/src/resolvers/types/workspace/index.js
+++ b/src/resolvers/types/workspace/index.js
@@ -38,23 +38,64 @@ export function deploymentCount(parent) {
  * @return {WorkspaceCapabilities} Map of boolean capabilities.
  */
 export function workspaceCapabilities(parent, args, ctx) {
-  // Check to see if user has permission to view and update billing
-  const canUpdateBilling = hasPermission(
-    ctx.user,
-    "workspace.billing.update",
-    ENTITY_WORKSPACE.toLowerCase(),
-    parent.id
-  );
+  const permissions = [
+    {
+      key: "canUpdateBilling",
+      value: "workspace.iam.update"
+    },
+    {
+      key: "canUpdateIAM",
+      value: "workspace.billing.update"
+    },
+    {
+      key: "canUpdateWorkspace",
+      value: "workspace.config.update"
+    },
+    {
+      key: "canDeleteWorkspace",
+      value: "workspace.config.delete"
+    },
+    {
+      key: "canCreateDeployment",
+      value: "workspace.deployments.create"
+    },
+    {
+      key: "canInviteUser",
+      value: "workspace.invites.get"
+    },
+    {
+      key: "canUpdateUser",
+      value: "workspace.iam.update"
+    },
+    {
+      key: "canDeleteUser",
+      value: "workspace.iam.update"
+    },
+    {
+      key: "canCreateServiceAccount",
+      value: "workspace.serviceAccounts.create"
+    },
+    {
+      key: "canUpdateServiceAccount",
+      value: "workspace.serviceAccounts.update"
+    },
+    {
+      key: "canDeleteServiceAccount",
+      value: "workspace.serviceAccounts.delete"
+    }
+  ];
 
-  // Check to see if user has permission to update roles
-  const canUpdateIAM = hasPermission(
-    ctx.user,
-    "workspace.iam.update",
-    ENTITY_WORKSPACE.toLowerCase(),
-    parent.id
-  );
+  const capabilities = [];
+  permissions.map(p => {
+    capabilities[p.key] = hasPermission(
+      ctx.user,
+      p.value,
+      ENTITY_WORKSPACE.toLowerCase(),
+      parent.id
+    );
+  });
 
-  return { canUpdateIAM, canUpdateBilling };
+  return capabilities;
 }
 
 // Check the config to see if stripe is enabled (Cloud mode)

--- a/src/resolvers/types/workspace/index.js
+++ b/src/resolvers/types/workspace/index.js
@@ -41,11 +41,11 @@ export function workspaceCapabilities(parent, args, ctx) {
   const permissions = [
     {
       key: "canUpdateBilling",
-      value: "workspace.iam.update"
+      value: "workspace.billing.update"
     },
     {
       key: "canUpdateIAM",
-      value: "workspace.billing.update"
+      value: "workspace.iam.update"
     },
     {
       key: "canUpdateWorkspace",

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -57,6 +57,11 @@ type AuthUser {
   token: Token
   permissions: JSON
   isAdmin: Boolean
+  authUserCapabilities: AuthUserCapabilities
+}
+
+type AuthUserCapabilities {
+  canSysAdmin: Boolean
 }
 
 type Token {
@@ -158,6 +163,15 @@ type AirflowImage {
 type WorkspaceCapabilities {
   canUpdateBilling: Boolean
   canUpdateIAM: Boolean
+  canUpdateWorkspace: Boolean
+  canDeleteWorkspace: Boolean
+  canCreateDeployment: Boolean
+  canInviteUser: Boolean
+  canUpdateUser: Boolean
+  canDeleteUser: Boolean
+  canCreateServiceAccount: Boolean
+  canUpdateServiceAccount: Boolean
+  canDeleteServiceAccount: Boolean
 }
 
 type AstroUnit {
@@ -207,6 +221,11 @@ type Deployment {
 
 type DeploymentCapabilities {
   canDeploy: Boolean
+  canUpdateDeployment: Boolean
+  canDeleteDeployment: Boolean
+  canCreateServiceAccount: Boolean
+  canUpdateServiceAccount: Boolean
+  canDeleteServiceAccount: Boolean
 }
 
 type ServiceAccount {


### PR DESCRIPTION
Extends `workspaceCapabilities` and `deploymentCapabilities` to handle more granular permissions server-side. Also adds `authUserCapabilities` to handle `sysAdmin` permissions. 

Ready for merge. 