### PR TITLE
Add support for Azure DB PostgreSQL - houston

### DIFF
--- a/src/lib/deployments/database/index.js
+++ b/src/lib/deployments/database/index.js
@@ -234,8 +234,6 @@ export function cleanCreator(creator) {
 // Get Azure DB Server name from username. Necessary for Azure DB PostgreSQL users.
 export function getAzureDbServer(user) {
   const dbServer = user.match(/@.*/g);
-  if (Array.isArray(dbServer))
-    return dbServer[0];
-  else
-    return "";
+  if (Array.isArray(dbServer)) return dbServer[0];
+  else return "";
 }

--- a/src/lib/deployments/database/index.js
+++ b/src/lib/deployments/database/index.js
@@ -45,6 +45,7 @@ export async function createDatabaseForDeployment(deployment) {
     length: 32,
     numbers: true
   });
+  const azureDbServerName = getAzureDbServer(parsedConn.user);
 
   log.info(`Creating database ${dbName}`);
 
@@ -88,7 +89,8 @@ export async function createDatabaseForDeployment(deployment) {
     pass: airflowPassword,
     host: parsedConn.host,
     port: parsedConn.port,
-    db: dbName
+    db: dbName,
+    azureDbServer: azureDbServerName
   };
 
   // Construt connection details for celery schema.
@@ -97,7 +99,8 @@ export async function createDatabaseForDeployment(deployment) {
     pass: celeryPassword,
     host: parsedConn.host,
     port: parsedConn.port,
-    db: dbName
+    db: dbName,
+    azureDbServer: azureDbServerName
   });
 
   // Return both urls.
@@ -226,4 +229,10 @@ export function parseConnection(conn) {
 // Strip '@dbserver' from username. Necessary for Azure DB PostgreSQL users.
 export function cleanCreator(creator) {
   return creator.replace(/@.*/g, '');
+}
+
+// Get Azure DB Server name from username. Necessary for Azure DB PostgreSQL users.
+export function getAzureDbServer(user) {
+  var match = user.match(/@.*/g);
+  return match[0];
 }

--- a/src/lib/deployments/database/index.js
+++ b/src/lib/deployments/database/index.js
@@ -37,8 +37,10 @@ export async function createDatabaseForDeployment(deployment) {
   const airflowSchemaName = "airflow";
   const celerySchemaName = "celery";
   const airflowUserName = generateAirflowUsername(deployment.releaseName);
+  // Format username as user@dbserver for Azure DB PostgreSQL connection
   const airflowConnUserName = airflowUserName + dbServerName;
   const celeryUserName = generateCeleryUsername(deployment.releaseName);
+  // Format username as user@dbserver for Azure DB PostgreSQL connection
   const celeryConnUserName = celeryUserName + dbServerName;
   const airflowPassword = passwordGenerator.generate({
     length: 32,

--- a/src/lib/deployments/database/index.js
+++ b/src/lib/deployments/database/index.js
@@ -174,9 +174,12 @@ export async function createSchema(
   schema,
   user,
   password,
-  creator,
+  admin,
   allowRootAccess
 ) {
+  // Ensure username is in proper format
+  const creator = cleanCreator(admin);
+
   // Create a new limited access user, with random password.
   await conn.raw(
     `CREATE USER ${user} WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION CONNECTION LIMIT -1 ENCRYPTED PASSWORD '${password}';`
@@ -218,4 +221,9 @@ export async function createSchema(
 export function parseConnection(conn) {
   if (isString(conn)) return parse(conn);
   return conn;
+}
+
+// Strip '@dbserver' from username. Necessary for Azure DB PostgreSQL users.
+export function cleanCreator(creator) {
+  return creator.replace(/@.*/g, '');
 }

--- a/src/lib/deployments/database/index.js
+++ b/src/lib/deployments/database/index.js
@@ -228,12 +228,15 @@ export function parseConnection(conn) {
 
 // Strip '@dbserver' from username. Necessary for Azure DB PostgreSQL users.
 export function cleanCreator(creator) {
+  log.info(`Formatting username ${creator}`);
   return creator.replace(/@.*/g, "");
 }
 
 // Get DB Server name from username. Necessary for Azure DB PostgreSQL users.
 export function getDbServer(user) {
   const dbServer = user.match(/@.*/g);
-  if (Array.isArray(dbServer)) return dbServer[0];
-  else return "";
+  if (Array.isArray(dbServer)) {
+    log.info(`Using db server name ${dbServer}`);
+    return dbServer[0];
+  } else return "";
 }

--- a/src/lib/deployments/database/index.js
+++ b/src/lib/deployments/database/index.js
@@ -233,6 +233,9 @@ export function cleanCreator(creator) {
 
 // Get Azure DB Server name from username. Necessary for Azure DB PostgreSQL users.
 export function getAzureDbServer(user) {
-  const match = user.match(/@.*/g);
-  return match[0];
+  const dbServer = user.match(/@.*/g);
+  if (Array.isArray(dbServer))
+    return dbServer[0];
+  else
+    return "";
 }

--- a/src/lib/deployments/database/index.js
+++ b/src/lib/deployments/database/index.js
@@ -233,6 +233,6 @@ export function cleanCreator(creator) {
 
 // Get Azure DB Server name from username. Necessary for Azure DB PostgreSQL users.
 export function getAzureDbServer(user) {
-  var match = user.match(/@.*/g);
+  const match = user.match(/@.*/g);
   return match[0];
 }

--- a/src/lib/deployments/database/index.js
+++ b/src/lib/deployments/database/index.js
@@ -228,7 +228,7 @@ export function parseConnection(conn) {
 
 // Strip '@dbserver' from username. Necessary for Azure DB PostgreSQL users.
 export function cleanCreator(creator) {
-  return creator.replace(/@.*/g, '');
+  return creator.replace(/@.*/g, "");
 }
 
 // Get Azure DB Server name from username. Necessary for Azure DB PostgreSQL users.

--- a/src/lib/deployments/database/index.unit.test.js
+++ b/src/lib/deployments/database/index.unit.test.js
@@ -1,0 +1,16 @@
+import * as databaseExports from "./index";
+
+describe("databaseExports.cleanCreator", () => {
+
+  test("test that cleanCreator function does not modify a normal username", async () => {
+    const creator = "user";
+    const cleaned = databaseExports.cleanCreator(creator);
+    expect(cleaned).toBe(creator);
+  });
+
+  test("test that cleanCreator function strips dbserver name from azure db username", async () => {
+    const creator = "user@azure-db";
+    const cleaned = databaseExports.cleanCreator(creator);
+    expect(cleaned).toBe("user");
+  });
+});

--- a/src/lib/deployments/database/index.unit.test.js
+++ b/src/lib/deployments/database/index.unit.test.js
@@ -13,15 +13,15 @@ describe("databaseExports.cleanCreator", () => {
     expect(cleaned).toBe("user");
   });
 
-  test("test if getAzureDbServer function gets azure dbserver name from azure db username", async () => {
+  test("test if getDbServer function gets azure dbserver name from azure db username", async () => {
     const creator = "user@azure-db";
-    const azureDbServer = databaseExports.getAzureDbServer(creator);
+    const azureDbServer = databaseExports.getDbServer(creator);
     expect(azureDbServer).toBe("@azure-db");
   });
 
-  test("test if getAzureDbServer function returns empty string for normal user", async () => {
+  test("test if getDbServer function returns empty string for normal user", async () => {
     const creator = "user";
-    const azureDbServer = databaseExports.getAzureDbServer(creator);
+    const azureDbServer = databaseExports.getDbServer(creator);
     expect(azureDbServer).toBe("");
   });
 });

--- a/src/lib/deployments/database/index.unit.test.js
+++ b/src/lib/deployments/database/index.unit.test.js
@@ -7,14 +7,32 @@ describe("databaseExports.cleanCreator", () => {
     expect(cleaned).toBe(creator);
   });
 
+  test("test if cleanCreator function does not modify a normal username", async () => {
+    const creator = "my-u$3r";
+    const cleaned = databaseExports.cleanCreator(creator);
+    expect(cleaned).toBe(creator);
+  });
+
   test("test if cleanCreator function strips dbserver name from azure db username", async () => {
     const creator = "user@azure-db";
     const cleaned = databaseExports.cleanCreator(creator);
     expect(cleaned).toBe("user");
   });
+  
+  test("test if cleanCreator function strips dbserver name from azure db username", async () => {
+    const creator = "my-u$3r@azure-db";
+    const cleaned = databaseExports.cleanCreator(creator);
+    expect(cleaned).toBe("my-u$3r");
+  });
 
   test("test if getDbServer function gets azure dbserver name from azure db username", async () => {
     const creator = "user@azure-db";
+    const azureDbServer = databaseExports.getDbServer(creator);
+    expect(azureDbServer).toBe("@azure-db");
+  });
+
+  test("test if getDbServer function gets azure dbserver name from azure db username", async () => {
+    const creator = "my-u$3r@azure-db";
     const azureDbServer = databaseExports.getDbServer(creator);
     expect(azureDbServer).toBe("@azure-db");
   });
@@ -24,4 +42,12 @@ describe("databaseExports.cleanCreator", () => {
     const azureDbServer = databaseExports.getDbServer(creator);
     expect(azureDbServer).toBe("");
   });
+
+  test("test if getDbServer function returns empty string for normal user", async () => {
+    const creator = "my-u$3r";
+    const azureDbServer = databaseExports.getDbServer(creator);
+    expect(azureDbServer).toBe("");
+  });
 });
+
+

--- a/src/lib/deployments/database/index.unit.test.js
+++ b/src/lib/deployments/database/index.unit.test.js
@@ -2,15 +2,21 @@ import * as databaseExports from "./index";
 
 describe("databaseExports.cleanCreator", () => {
 
-  test("test that cleanCreator function does not modify a normal username", async () => {
+  test("test if cleanCreator function does not modify a normal username", async () => {
     const creator = "user";
     const cleaned = databaseExports.cleanCreator(creator);
     expect(cleaned).toBe(creator);
   });
 
-  test("test that cleanCreator function strips dbserver name from azure db username", async () => {
+  test("test if cleanCreator function strips dbserver name from azure db username", async () => {
     const creator = "user@azure-db";
     const cleaned = databaseExports.cleanCreator(creator);
     expect(cleaned).toBe("user");
+  });
+
+  test("test if getAzureDbServer function gets azure dbserver name from azure db username", async () => {
+    const creator = "user@azure-db";
+    const azureDbServer = databaseExports.getAzureDbServer(creator);
+    expect(azureDbServer).toBe("@azure-db");
   });
 });

--- a/src/lib/deployments/database/index.unit.test.js
+++ b/src/lib/deployments/database/index.unit.test.js
@@ -18,4 +18,10 @@ describe("databaseExports.cleanCreator", () => {
     const azureDbServer = databaseExports.getAzureDbServer(creator);
     expect(azureDbServer).toBe("@azure-db");
   });
+
+  test("test if getAzureDbServer function returns empty string for normal user", async () => {
+    const creator = "user";
+    const azureDbServer = databaseExports.getAzureDbServer(creator);
+    expect(azureDbServer).toBe("");
+  });
 });

--- a/src/lib/deployments/database/index.unit.test.js
+++ b/src/lib/deployments/database/index.unit.test.js
@@ -1,7 +1,6 @@
 import * as databaseExports from "./index";
 
 describe("databaseExports.cleanCreator", () => {
-
   test("test if cleanCreator function does not modify a normal username", async () => {
     const creator = "user";
     const cleaned = databaseExports.cleanCreator(creator);

--- a/src/lib/deployments/database/index.unit.test.js
+++ b/src/lib/deployments/database/index.unit.test.js
@@ -18,7 +18,7 @@ describe("databaseExports.cleanCreator", () => {
     const cleaned = databaseExports.cleanCreator(creator);
     expect(cleaned).toBe("user");
   });
-  
+
   test("test if cleanCreator function strips dbserver name from azure db username", async () => {
     const creator = "my-u$3r@azure-db";
     const cleaned = databaseExports.cleanCreator(creator);
@@ -49,5 +49,3 @@ describe("databaseExports.cleanCreator", () => {
     expect(azureDbServer).toBe("");
   });
 });
-
-


### PR DESCRIPTION
fix issue https://github.com/astronomer/issues/issues/102
- Add function `cleanCreator` to strip away `@dbserver` from username
- Add function `getAzureDbServer` to get `@dbserver` from username
- Add `@dbserver` to `metadataConnection` and `resultBackendConnection`
  - These values will be passed to the airflow chart and used in `pgbouncer-config` https://github.com/astronomer/airflow-chart/pull/32
- Add unit tests for the above functions
- Required for use with Azure DB for PostgreSQL