### PR TITLE
Add email addresses to track call body

### DIFF
--- a/src/lib/analytics/index.js
+++ b/src/lib/analytics/index.js
@@ -1,3 +1,4 @@
+import { prisma } from "generated/client";
 import config from "config";
 const Analytics = require("analytics-node");
 
@@ -17,6 +18,8 @@ export function identify(userId, traits) {
 
 export function track(userId, event, properties) {
   if (client) {
+    const email = usersQuery(userId);
+    properties.email = email;
     client.track({ userId, event, properties });
   }
 }
@@ -25,4 +28,9 @@ export function group(userId, groupId, traits) {
   if (client) {
     client.group({ userId, groupId, traits });
   }
+}
+
+export async function usersQuery(id) {
+  const email = await prisma.user({ id }).email;
+  return email;
 }


### PR DESCRIPTION
This PR gives us a user's email address on the `properties` object of each track call. This allows us to use the email in streaming slack messages and loads the email into all of our Snowflake tables along with the userId.