### PR TITLE
fix typo with deployment

### DIFF
--- a/src/lib/deployments/config/index.js
+++ b/src/lib/deployments/config/index.js
@@ -53,7 +53,7 @@ export function generateHelmValues(deployment, values = {}) {
     {}, // Start with an empty object.
     base, // Apply base settings from config YAML.
     values, // Apply any settings passed in directly.
-    ingress(), // Apply ingress settings.
+    ingress(deployment), // Apply ingress settings.
     defaultResources(), // Apply resource requests and limits.
     limitRange(), // Apply the limit range.
     constraints(deployment), // Apply any constraints (quotas, pgbouncer, etc).
@@ -75,7 +75,7 @@ export function generateHelmValues(deployment, values = {}) {
  * Return the Ingress configuration.
  * @return {Object} Ingress values.
  */
-export function ingress() {
+export function ingress(deployment) {
   const { baseDomain, releaseName } = config.get("helm");
 
   const ingressClass = `${releaseName}-nginx`;
@@ -85,7 +85,7 @@ export function ingress() {
     "nginx.ingress.kubernetes.io/custom-http-errors": "403,404,502,503",
     "nginx.ingress.kubernetes.io/auth-url": `${houston()}/v1/authorization`,
     "nginx.ingress.kubernetes.io/auth-signin": `${ui()}/login`,
-    "nginx.ingress.kubernetes.io/proxy-cookie-path": `/ /${releaseName}/`,
+    "nginx.ingress.kubernetes.io/proxy-cookie-path": `/ /${deployment.releaseName}/`,
     "nginx.ingress.kubernetes.io/auth-response-headers":
       "authorization, username, email"
   };
@@ -117,7 +117,7 @@ export function ingress() {
                rewrite ^ ${deploymentsUrl()}/flower permanent;
              }
              subs_filter_types text/css text/xml text/css;
-             sub_filter '="/' '="/${releaseName}/flower/';
+             sub_filter '="/' '="/${deployment.releaseName}/flower/';
              sub_filter_last_modified on;
              sub_filter_once off;`
         },


### PR DESCRIPTION
before this fix `nginx.ingress.kubernetes.io/proxy-cookie-path:` has wrong path:
```
Annotations:
  kubernetes.io/ingress.class:                        astronomer-nginx
  nginx.ingress.kubernetes.io/auth-response-headers:  authorization, username, email
  nginx.ingress.kubernetes.io/auth-signin:            https://app.local.astronomer-development.com/login
  nginx.ingress.kubernetes.io/auth-url:               http://astronomer-houston.astronomer.svc.cluster.local:8871/v1/authorization
  nginx.ingress.kubernetes.io/configuration-snippet:
             if ($host = 'astronomer-airflow.local.astronomer-development.com' ) {
               return 308 https://deployments.local.astronomer-development.com/airflow/$request_uri;
             }
  nginx.ingress.kubernetes.io/custom-http-errors:  403,404,502,503
  nginx.ingress.kubernetes.io/proxy-cookie-path:   / /astronomer/
```

**correct path:**

```
Annotations:
  nginx.ingress.kubernetes.io/configuration-snippet:
             if ($host = 'astronomer-airflow.local.astronomer-development.com' ) {
               return 308 https://deployments.local.astronomer-development.com/airflow/$request_uri;
             }
  nginx.ingress.kubernetes.io/custom-http-errors:  403,404,502,503
  nginx.ingress.kubernetes.io/proxy-cookie-path:   / /physical-isotope-4070/

```